### PR TITLE
Add admin approval for new accounts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,18 +18,19 @@ function App() {
       let savedUsers = JSON.parse(localStorage.getItem('users')) || [];
       if (savedUsers.length === 0) {
         const initialUsers = [
-          { username: 'admin', password: 'admin', role: 'admin' },
-          { username: 'غيث صلاح مهدي', password: '1', role: 'creator' }
+          { username: 'admin', password: 'admin', role: 'admin', approved: true },
+          { username: 'غيث صلاح مهدي', password: '1', role: 'creator', approved: true }
         ];
         savedUsers = initialUsers;
         localStorage.setItem('users', JSON.stringify(initialUsers));
       } else {
         savedUsers = savedUsers.map(u => ({
           ...u,
-          role: u.role || (u.username === 'admin' ? 'admin' : 'technician')
+          role: u.role || (u.username === 'admin' ? 'admin' : 'technician'),
+          approved: typeof u.approved === 'undefined' ? true : u.approved
         }));
         if (!savedUsers.some(u => u.username === 'غيث صلاح مهدي')) {
-            savedUsers.push({ username: 'غيث صلاح مهدي', password: '1', role: 'creator' });
+            savedUsers.push({ username: 'غيث صلاح مهدي', password: '1', role: 'creator', approved: true });
         }
         localStorage.setItem('users', JSON.stringify(savedUsers));
       }

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -12,6 +12,7 @@ import DashTasksTable from '@/components/DashTasksTable';
 import TaskLimitManager from '@/components/tasks/TaskLimitManager';
 import GoogleSheetsManager from '@/components/GoogleSheetsManager';
 import SupabaseSetup from '@/components/config/SupabaseSetup';
+import UserApproval from '@/components/UserApproval';
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -138,7 +139,18 @@ const AdminView = ({ tasks, users, onUpdateUsers, reports, onUpdateTasks, onUpda
       </TabsContent>
       
       <TabsContent value="users" className="mt-6">
-        <UserManager users={users} onUpdateUsers={onUpdateUsers} />
+        <Tabs defaultValue="manage" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 glass-effect">
+            <TabsTrigger value="manage">إدارة المستخدمين</TabsTrigger>
+            <TabsTrigger value="approval">الموافقة</TabsTrigger>
+          </TabsList>
+          <TabsContent value="manage" className="mt-6">
+            <UserManager users={users} onUpdateUsers={onUpdateUsers} />
+          </TabsContent>
+          <TabsContent value="approval" className="mt-6">
+            <UserApproval users={users} onUpdateUsers={onUpdateUsers} />
+          </TabsContent>
+        </Tabs>
       </TabsContent>
       
       <TabsContent value="inventory" className="mt-6">

--- a/src/components/AuthPage.jsx
+++ b/src/components/AuthPage.jsx
@@ -27,8 +27,12 @@ const AuthPage = ({ onLogin, onUpdateUsers }) => {
   const handleLogin = () => {
     const users = JSON.parse(localStorage.getItem('users')) || [];
     const foundUser = users.find(u => u.username === username && u.password === password);
-
+    
     if (foundUser) {
+      if (foundUser.approved === false) {
+        toast({ title: "قيد المراجعة", description: "حسابك بانتظار موافقة المشرف.", variant: "destructive" });
+        return;
+      }
       toast({ title: `مرحباً بعودتك، ${foundUser.username}!` });
       onLogin(foundUser);
     } else {
@@ -47,10 +51,10 @@ const AuthPage = ({ onLogin, onUpdateUsers }) => {
     if (userExists) {
       toast({ title: "خطأ", description: "اسم المستخدم هذا موجود بالفعل.", variant: "destructive" });
     } else {
-      const newUser = { username, password, role: 'technician' }; // New users are technicians
+      const newUser = { username, password, role: 'technician', approved: false };
       const updatedUsers = [...users, newUser];
       onUpdateUsers(updatedUsers);
-      toast({ title: "نجاح!", description: "تم إنشاء حسابك بنجاح. يمكنك الآن تسجيل الدخول." });
+      toast({ title: "تم إنشاء الحساب", description: "سيتم تفعيل حسابك بعد موافقة المشرف." });
       setIsRegister(false);
       setUsername('');
       setPassword('');

--- a/src/components/UserApproval.jsx
+++ b/src/components/UserApproval.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { Check, X } from 'lucide-react';
+
+const UserApproval = ({ users, onUpdateUsers }) => {
+  const { toast } = useToast();
+  const pendingUsers = users.filter(u => u.approved === false);
+
+  const approveUser = (username) => {
+    const updatedUsers = users.map(u =>
+      u.username === username ? { ...u, approved: true } : u
+    );
+    onUpdateUsers(updatedUsers);
+    toast({ title: 'تمت الموافقة', description: `تم تفعيل حساب ${username}` });
+  };
+
+  const rejectUser = (username) => {
+    const updatedUsers = users.filter(u => u.username !== username);
+    onUpdateUsers(updatedUsers);
+    toast({ title: 'تم الرفض', description: `تم حذف حساب ${username}` });
+  };
+
+  return (
+    <Card className="glass-effect border-sky-500/20">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-3 text-2xl gradient-text font-bold">
+          الموافقة على الحسابات
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {pendingUsers.length === 0 ? (
+          <p className="text-center text-gray-400 py-8">لا توجد حسابات قيد الانتظار.</p>
+        ) : (
+          pendingUsers.map(user => (
+            <div key={user.username} className="flex items-center justify-between p-3 rounded-lg bg-slate-800/50">
+              <p className="font-semibold text-sky-300">{user.username}</p>
+              <div className="space-x-2 space-x-reverse">
+                <Button size="sm" onClick={() => approveUser(user.username)} className="bg-green-600 hover:bg-green-700">
+                  <Check className="w-4 h-4 ml-1" /> موافقة
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => rejectUser(user.username)}>
+                  <X className="w-4 h-4 ml-1" /> رفض
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UserApproval;

--- a/src/components/UserManager.jsx
+++ b/src/components/UserManager.jsx
@@ -43,7 +43,10 @@ const UserManager = ({ users, onUpdateUsers }) => {
     setEditingUser(null);
   };
 
-  const editableUsers = users.filter(u => u.role === 'admin' || u.role === 'technician' || u.role === 'creator');
+  const editableUsers = users.filter(u =>
+    (u.role === 'admin' || u.role === 'technician' || u.role === 'creator') &&
+    u.approved !== false
+  );
 
   return (
     <Card className="glass-effect border-sky-500/20">


### PR DESCRIPTION
## Summary
- require approval on signup
- block login until approved
- track approval state in stored users
- show new Approval tab under Users for admins
- filter user editor to approved accounts

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687220b398e883209fe018d029aa2b29