### PR TITLE
Add supervisor approvals tab

### DIFF
--- a/src/components/AccountApprovals.jsx
+++ b/src/components/AccountApprovals.jsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { fetchPendingUsers, approveUser, rejectUser } from '@/services/userService';
+
+const AccountApprovals = () => {
+  const { toast } = useToast();
+  const [pendingUsers, setPendingUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      const { data, error } = await fetchPendingUsers();
+      if (error) {
+        toast({
+          variant: 'destructive',
+          title: 'خطأ',
+          description: 'فشل جلب المستخدمين.'
+        });
+      } else {
+        setPendingUsers(data || []);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [toast]);
+
+  const handleApprove = async (id) => {
+    const { error } = await approveUser(id);
+    if (error) {
+      toast({ variant: 'destructive', title: 'خطأ', description: 'فشل الموافقة.' });
+    } else {
+      setPendingUsers(prev => prev.filter(u => u.id !== id));
+      toast({ title: 'تمت الموافقة', description: 'تمت الموافقة على المستخدم.' });
+    }
+  };
+
+  const handleReject = async (id) => {
+    const { error } = await rejectUser(id);
+    if (error) {
+      toast({ variant: 'destructive', title: 'خطأ', description: 'فشل الرفض.' });
+    } else {
+      setPendingUsers(prev => prev.filter(u => u.id !== id));
+      toast({ title: 'تم الرفض', description: 'تم حذف المستخدم.' });
+    }
+  };
+
+  return (
+    <Card className="glass-effect border-sky-500/20">
+      <CardHeader>
+        <CardTitle className="text-2xl gradient-text font-bold">الحسابات المعلقة</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-center">جاري التحميل...</p>
+        ) : pendingUsers.length === 0 ? (
+          <p className="text-center text-gray-400">لا توجد حسابات معلقة.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-sky-300">
+                <th className="p-2 text-right">المستخدم</th>
+                <th className="p-2 text-right">البريد</th>
+                <th className="p-2 text-right">تاريخ الإنشاء</th>
+                <th className="p-2 text-center">الإجراءات</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pendingUsers.map((u) => (
+                <tr key={u.id} className="border-b border-slate-700/50">
+                  <td className="p-2">{u.username}</td>
+                  <td className="p-2">{u.email}</td>
+                  <td className="p-2">
+                    {u.created_at ? new Date(u.created_at).toLocaleDateString() : ''}
+                  </td>
+                  <td className="p-2 flex gap-2 justify-center">
+                    <Button size="sm" onClick={() => handleApprove(u.id)}>
+                      موافقة
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleReject(u.id)}
+                    >
+                      رفض
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AccountApprovals;

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CheckCircle, Clock, XCircle, Users, BarChart2, Package, TrendingUp, Shield, Settings } from 'lucide-react';
 import UserManager from '@/components/UserManager';
+import AccountApprovals from '@/components/AccountApprovals';
 import PermissionManager from '@/components/PermissionManager';
 import EnhancedFinancialManager from '@/components/EnhancedFinancialManager';
 import MaterialInventoryManager from '@/components/MaterialInventoryManager';
@@ -26,7 +27,7 @@ const TaskStatusCard = ({ title, count, icon, color }) => (
   </Card>
 );
 
-const AdminView = ({ tasks, users, onUpdateUsers, reports, onUpdateTasks, onUpdateReports }) => {
+const AdminView = ({ tasks, users, onUpdateUsers, reports, onUpdateTasks, onUpdateReports, currentUser }) => {
   const technicians = users.filter(u => u.role === 'technician');
 
   const taskStats = {
@@ -57,6 +58,9 @@ const AdminView = ({ tasks, users, onUpdateUsers, reports, onUpdateTasks, onUpda
         <TabsTrigger value="dash" className="text-xs shrink-0">📊 مهام الداش</TabsTrigger>
         <TabsTrigger value="subscribers" className="text-xs shrink-0"><TrendingUp className="w-3 h-3 ml-1" />المشتركون</TabsTrigger>
         <TabsTrigger value="users" className="text-xs shrink-0"><Users className="w-3 h-3 ml-1" />المستخدمون</TabsTrigger>
+        {currentUser?.role === 'supervisor' && (
+          <TabsTrigger value="approvals" className="text-xs shrink-0">الموافقات</TabsTrigger>
+        )}
         <TabsTrigger value="inventory" className="text-xs shrink-0"><Package className="w-3 h-3 ml-1" />المخزون</TabsTrigger>
         <TabsTrigger value="financial" className="text-xs shrink-0">💰 الذمة المالية</TabsTrigger>
         <TabsTrigger value="sheets" className="text-xs shrink-0">📊 Google Sheets</TabsTrigger>
@@ -138,7 +142,12 @@ const AdminView = ({ tasks, users, onUpdateUsers, reports, onUpdateTasks, onUpda
       <TabsContent value="users" className="mt-6">
         <UserManager users={users} onUpdateUsers={onUpdateUsers} />
       </TabsContent>
-      
+      {currentUser?.role === 'supervisor' && (
+        <TabsContent value="approvals" className="mt-6">
+          <AccountApprovals />
+        </TabsContent>
+      )}
+
       <TabsContent value="inventory" className="mt-6">
         <MaterialInventoryManager users={users} reports={reports} onUpdateUsers={onUpdateUsers} />
       </TabsContent>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -87,13 +87,14 @@ const Dashboard = ({ user, onLogout, users, onUpdateUsers, view, setView }) => {
           </TabsList>
           <TabsContent value="overview" className="mt-4">
             <Suspense fallback={<LoadingSpinner />}>
-              <AdminView 
-                tasks={tasks} 
-                users={users} 
-                onUpdateUsers={onUpdateUsers} 
-                reports={reports} 
+              <AdminView
+                tasks={tasks}
+                users={users}
+                onUpdateUsers={onUpdateUsers}
+                reports={reports}
                 onUpdateTasks={updateTasks}
                 onUpdateReports={updateReports}
+                currentUser={user}
               />
             </Suspense>
           </TabsContent>

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,36 @@
+import { supabase } from '@/lib/customSupabaseClient';
+
+/**
+ * Fetches all users with `approved = false`.
+ * @returns {Promise<{ data: any, error: any }>} Supabase response
+ */
+export const fetchPendingUsers = async () => {
+  return await supabase
+    .from('users')
+    .select('id, username, email, created_at')
+    .eq('approved', false);
+};
+
+/**
+ * Marks a user as approved.
+ * @param {string|number} userId - ID of the user to approve
+ * @returns {Promise<{ data: any, error: any }>} Supabase response
+ */
+export const approveUser = async (userId) => {
+  return await supabase
+    .from('users')
+    .update({ approved: true })
+    .eq('id', userId);
+};
+
+/**
+ * Deletes or rejects a pending user.
+ * @param {string|number} userId - ID of the user to reject
+ * @returns {Promise<{ data: any, error: any }>} Supabase response
+ */
+export const rejectUser = async (userId) => {
+  return await supabase
+    .from('users')
+    .delete()
+    .eq('id', userId);
+};


### PR DESCRIPTION
## Summary
- add new `AccountApprovals` component for reviewing pending accounts
- create `userService` with Supabase functions
- show "الموافقات" tab only for supervisors
- wire approvals tab content in AdminView
- pass current user info from Dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68758d713cd483209e5b4e25314af1b7